### PR TITLE
Implement basic delegates for common types

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,17 @@ suspend fun <T, M: PaginationAction<T, M>> M.produce(scope: CoroutineScope = Glo
 suspend fun <T, M: PaginationAction<T, M>> M.asFlow(scope: CoroutineScope = GlobalScope): Flow<T>
 ```
 
+### Delegates
+
+This library implements [delegate properties](https://kotlinlang.org/docs/reference/delegated-properties.html) which can be used to safely keep references of JDA entities such as users/channels.
+These delegates can be used with the [`ref()`](https://github.com/MinnDevelopment/jda-ktx/tree/master/src/main/java/dev/minn/jda/ktx/proxies.kt) extension function:
+
+```kotlin
+class Foo(guild: Guild) {
+    val guild : Guild by guild.ref()
+}
+```
+
 ## Download
 
 [![](https://api.bintray.com/packages/minndevelopment/maven/jda-ktx/images/download.svg)](https://bintray.com/minndevelopment/maven/jda-ktx)

--- a/src/main/kotlin/dev/minn/jda/ktx/proxies.kt
+++ b/src/main/kotlin/dev/minn/jda/ktx/proxies.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2020 Florian Spieß
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.minn.jda.ktx
+
+import net.dv8tion.jda.api.entities.*
+import kotlin.reflect.KProperty
+
+open class BackedReference<T>(private var entity: T, private val update: (T) -> T?) {
+    operator fun getValue(thisRef: Any?, prop: KProperty<*>): T {
+        entity = update(entity) ?: entity
+        return entity
+    }
+}
+
+fun User.ref() = BackedReference(this) {
+    this.jda.getUserById(this.idLong)
+}
+
+fun Member.ref() = BackedReference(this) {
+    guild.getMemberById(idLong)
+}
+
+fun Guild.ref() = BackedReference(this) {
+    jda.getGuildById(idLong)
+}
+
+fun Role.ref() = BackedReference(this) {
+    guild.getRoleById(idLong)
+}
+
+fun PrivateChannel.ref() = BackedReference(this) {
+    jda.getPrivateChannelById(idLong)
+}
+
+@Suppress("UNCHECKED_CAST")
+fun <T : GuildChannel> T.ref() = BackedReference(this) {
+    jda.getGuildChannelById(type, idLong) as T
+}
+
+// Example Usage:
+
+/*
+
+class ModLog(channel: TextChannel) {
+    private val channel: TextChannel by channel.ref()
+
+    fun onBan(target: User, moderator: Member, reason: String? = null) {
+        channel.sendMessage(EmbedBuilder().run {
+            setColor(0xa83636)
+            setAuthor(moderator.user.asTag, null, moderator.user.avatarUrl)
+            setDescription("Banned %#s (%s)".format(target, target.id))
+            setTimestamp(Instant.now())
+            if (reason != null)
+                appendDescription("\n Reason: ").appendDescription(reason)
+            build()
+        }).queue()
+    }
+}
+
+class GuildEnvironment(val prefix: String, guild: Guild, modLog: Long) {
+    val guild: Guild by guild.ref()
+    val modLog = ModLog(guild.getTextChannelById(modLog)!!)
+}
+
+ */


### PR DESCRIPTION
This allows to safely store entities in fields using special delegates that update the reference when needed. JDA does something similar internally, but this can be done very nicely in kotlin.

Example usage:

```kotlin
class Foo(user: User) {
  val user : User by user.ref()
}
```