### PR TITLE
[Bug] Int in generic is preceived as java.lang.Integer instead

### DIFF
--- a/src/main/kotlin/dev/minn/jda/ktx/interactions/utils.kt
+++ b/src/main/kotlin/dev/minn/jda/ktx/interactions/utils.kt
@@ -23,7 +23,7 @@ import net.dv8tion.jda.api.entities.User
 import net.dv8tion.jda.api.interactions.commands.OptionType
 
 inline fun <reified T> optionType() = when(T::class.java) {
-    Integer::class.java -> OptionType.INTEGER
+    Integer::class.java, java.lang.Long::class.java, java.lang.Short::class.java, java.lang.Byte::class.java -> OptionType.INTEGER
     String::class.java -> OptionType.STRING
     User::class.java -> OptionType.USER
     Role::class.java -> OptionType.ROLE

--- a/src/main/kotlin/dev/minn/jda/ktx/interactions/utils.kt
+++ b/src/main/kotlin/dev/minn/jda/ktx/interactions/utils.kt
@@ -23,7 +23,7 @@ import net.dv8tion.jda.api.entities.User
 import net.dv8tion.jda.api.interactions.commands.OptionType
 
 inline fun <reified T> optionType() = when(T::class.java) {
-    Int::class.java -> OptionType.INTEGER
+    Integer::class.java -> OptionType.INTEGER
     String::class.java -> OptionType.STRING
     User::class.java -> OptionType.USER
     Role::class.java -> OptionType.ROLE


### PR DESCRIPTION
Int used in generic is preceived as Java's native wrapper java.lang.Integer instead of kotlin.Int (int),

I've tested `1468ea8` with JDA `4.3.0_281` & kotlin`1.4.32` & `1.5.10` and varied the JDA version to `4.2.1_273` aswell.

However i keep getting a persistent `java.lang.IllegalArgumentException: Cannot resolve type Integer to OptionType!` from
```kotlin
    val type = optionType<T>()
    if (type == OptionType.UNKNOWN)
        throw IllegalArgumentException("Cannot resolve type " + T::class.java.simpleName + " to OptionType!")
```
when building commands using integer choices.

I suspect that kotlins Int gets optimized differently when it's used as a generic or just in plain code.
I can't find any other fix, i'm unsure if this breaks compatibility with older kotlin versions.