### PR TITLE
Implement useful send abstractions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ jda.listener<MessageReceivedEvent> {
 
 jda.onCommand("ban") { event ->
     val user = event.getOption("user")!!.asUser
-    val confirm = Button.danger("${user.id}:ban", "Confirm")
+    val confirm = danger("${user.id}:ban", "Confirm")
     event.reply_(
         "Are you sure you want to ban **${user.asTag}**?",
         components=confirm.into(),

--- a/README.md
+++ b/README.md
@@ -59,11 +59,11 @@ jda.onCommand("ban") { event ->
         val pressed = event.user.awaitButton(confirm) // await for user to click button
         pressed.deferEdit().queue() // Acknowledge the button press
         event.guild.ban(user, 0).queue() // the button is pressed -> execute action
-    } ?: event.hook.editOriginal("Timed out.").setActionRows(emptyList()).queue()
+    } ?: event.hook.editMessage(/*id="@original" is default */content="Timed out.", components=emptyList()).queue()
 }
 
 jda.onButton("hello") { // Button that says hello
-    it.reply("Hello :)").queue()
+    it.reply_("Hello :)").queue()
 }
 ```
 
@@ -219,7 +219,7 @@ jda.onCommand("ban") { event ->
         butt.hook.deleteOriginal().queue() // automatically acknowledged if callback does not do it
     }
 
-    event.reply("Are you sure?")
+    event.reply_("Are you sure?")
         .addActionRow(accept, deny) // send your buttons
         .queue()
 }

--- a/README.md
+++ b/README.md
@@ -38,24 +38,23 @@ jda.listener<MessageReceivedEvent> {
             // Take first result, or null
             matches.firstOrNull()
         }
-        
+
         if (user == null) // unknown user for name
-            channel.sendMessageFormat("%s, I cannot find a user for your query!", it.author).queue()
+            channel.send("${it.author.asMention}, I cannot find a user for your query!").queue()
         else // load profile and send it as embed
-            channel.sendMessageFormat("%s, here is the user profile:", it.author)
-                .embed(profile(user)) // custom profile embed implementation
-                .queue()
+            channel.send("${it.author.asMention}, here is the user profile:", embed=profile(user)).queue()
     }
 }
 
 jda.onCommand("ban") { event ->
     val user = event.getOption("user")!!.asUser
     val confirm = Button.danger("${user.id}:ban", "Confirm")
-    event.reply("Are you sure you want to ban **${user.asTag}**?")
-        .addActionRow(confirm)
-        .setEphemeral(true)
-        .queue()
-    
+    event.reply_(
+        "Are you sure you want to ban **${user.asTag}**?",
+        components=confirm.into(),
+        ephemeral=true
+    ).queue()
+
     withTimeoutOrNull(60000) { // 1 minute timeout
         val pressed = event.user.awaitButton(confirm) // await for user to click button
         pressed.deferEdit().queue() // Acknowledge the button press
@@ -119,7 +118,7 @@ object Listener : ListenerAdapter() {
     private val log by SLF4J 
 
     override fun onMessageReceived(event: MessageReceivedEvent) {
-        log.info("[{}] {}: {}", event.channel.name, event.author.asTag, event.message.contentDispaly)
+        log.info("[{}] {}: {}", event.channel.name, event.author.asTag, event.message.contentDisplay)
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -230,6 +230,32 @@ jda.onButton("accept") { event ->
 }
 ```
 
+### Sending Messages
+
+This library also adds some more kotlin idiomatic message send/edit extensions which rely on named parameters.
+These named parameters also support defaults, which can be modified by `SendDefaults` and `MessageEditDefaults`.
+
+In order to avoid overload conflicts with methods from JDA, some functions may use a suffixed `_` such as `reply_` or `editMessage_`.
+This is simply done to prevent you from accidentally calling the wrong overload which doesn't use the defaults of this library.
+If you don't care about that, you can simply add an import alias with `import dev.minn.jda.ktx.message.reply_ as reply`.
+
+Example:
+
+```ktx
+SendDefaults.ephemeral = true // <- all reply_ calls set ephemeral=true by default
+MessageEditDefaults.replace = false // <- only apply explicitly set parameters (default behavior)
+jda.onCommand("ban") { event ->
+    if (!event.member.hasPermission(Permission.BAN_MEMBERS))
+        return@onCommand event.reply_("You can't do that!").queue()
+    
+    event.reply_("Are you sure?", components=danger("ban", "Yes!").into())
+    val interaction = event.user.awaitButton("ban")
+    val user = event.getOption("target")!!.asUser
+    event.guild!!.ban(user, 0).queue()
+    interaction.editMessage_("Successfully banned user", components=emptyList()).queue()
+}
+```
+
 
 ## Download
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "dev.minn"
-version = "0.8.0-alpha.1"
+version = "0.8.1-alpha.1"
 
 configure<JavaPluginConvention> {
     sourceCompatibility = JavaVersion.VERSION_1_8

--- a/src/main/kotlin/dev/minn/jda/ktx/CoroutineEventManager.kt
+++ b/src/main/kotlin/dev/minn/jda/ktx/CoroutineEventManager.kt
@@ -34,7 +34,7 @@ private val log: Logger by SLF4J<CoroutineEventManager>()
  * This enables [the coroutine listener extension][listener].
  */
 class CoroutineEventManager(
-    private val scope: CoroutineScope = GlobalScope,
+    val scope: CoroutineScope = GlobalScope,
     /** Timeout in milliseconds each event listener is allowed to run. Set to -1 for no timeout. Default: -1 */
     var timeout: Long = -1
 ) : IEventManager {

--- a/src/main/kotlin/dev/minn/jda/ktx/inject.kt
+++ b/src/main/kotlin/dev/minn/jda/ktx/inject.kt
@@ -16,8 +16,12 @@
 
 package dev.minn.jda.ktx
 
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.GlobalScope
+import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.JDABuilder
 import net.dv8tion.jda.api.sharding.DefaultShardManagerBuilder
+import net.dv8tion.jda.api.sharding.ShardManager
 
 /**
  * Applies the [CoroutineEventManager] to this builder.
@@ -28,3 +32,17 @@ fun JDABuilder.injectKTX(timeout: Long = -1) = setEventManager(CoroutineEventMan
  * Applies the [CoroutineEventManager] to this builder.
  */
 fun DefaultShardManagerBuilder.injectKTX(timeout: Long = -1) = setEventManagerProvider { CoroutineEventManager(timeout=timeout) }
+
+/**
+ * The coroutine scope used by the underlying [CoroutineEventManager].
+ * If this instance does not use the coroutine event manager, this returns [GlobalScope] instead.
+ */
+val JDA.scope: CoroutineScope get() = (eventManager as? CoroutineEventManager)?.scope ?: GlobalScope
+
+/**
+ * The coroutine scope used by the underlying [CoroutineEventManager].
+ * If this instance does not use the coroutine event manager, this returns [GlobalScope] instead.
+ *
+ * @throws[NoSuchElementException] If no shards are currently available
+ */
+val ShardManager.scope: CoroutineScope get() = (shardCache.first().eventManager as? CoroutineEventManager)?.scope ?: GlobalScope

--- a/src/main/kotlin/dev/minn/jda/ktx/interactions/buttons.kt
+++ b/src/main/kotlin/dev/minn/jda/ktx/interactions/buttons.kt
@@ -17,7 +17,7 @@
 package dev.minn.jda.ktx.interactions
 
 import dev.minn.jda.ktx.onButton
-import kotlinx.coroutines.GlobalScope
+import dev.minn.jda.ktx.scope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import net.dv8tion.jda.api.JDA
@@ -188,7 +188,7 @@ fun link(
  *
  * @return[Button] The resulting button instance. You still need to send it with a message!
  */
-suspend fun JDA.button(style: ButtonStyle = ButtonDefaults.STYLE, label: String? = ButtonDefaults.LABEL, emoji: Emoji? = ButtonDefaults.EMOJI,
+fun JDA.button(style: ButtonStyle = ButtonDefaults.STYLE, label: String? = ButtonDefaults.LABEL, emoji: Emoji? = ButtonDefaults.EMOJI,
                        disabled: Boolean = ButtonDefaults.DISABLED,
                        expiration: Long = ButtonDefaults.EXPIRATION, user: User? = null, listener: suspend (ButtonClickEvent) -> Unit
 ): Button {
@@ -202,7 +202,7 @@ suspend fun JDA.button(style: ButtonStyle = ButtonDefaults.STYLE, label: String?
             it.deferEdit().queue()
     }
     if (expiration > 0) {
-        GlobalScope.launch {
+        scope.launch {
             delay(expiration)
             removeEventListener(task)
         }

--- a/src/main/kotlin/dev/minn/jda/ktx/interactions/buttons.kt
+++ b/src/main/kotlin/dev/minn/jda/ktx/interactions/buttons.kt
@@ -46,7 +46,130 @@ object ButtonDefaults {
     var LABEL: String? = null
     /** The default button emoji */
     var EMOJI: Emoji? = null
+    /** The default button disabled state */
+    var DISABLED: Boolean = false
 }
+
+/**
+ * Create a button with keyword arguments.
+ *
+ * This will use the defaults from [ButtonDefaults] unless specified as parameters.
+ *
+ * @param[id] The component id to use.
+ * @param[style] The button style.
+ * @param[label] The button label
+ * @param[emoji] The button emoji
+ *
+ * @return[Button] The resulting button instance.
+ */
+fun button(
+   id: String,
+   label: String? = ButtonDefaults.LABEL,
+   emoji: Emoji? = ButtonDefaults.EMOJI,
+   style: ButtonStyle = ButtonDefaults.STYLE,
+   disabled: Boolean = ButtonDefaults.DISABLED,
+) = Button.of(style, id, label, emoji).withDisabled(disabled)
+
+/**
+ * Create a button with keyword arguments.
+ *
+ * This is a shortcut for a button of style primary.
+ *
+ * This will use the defaults from [ButtonDefaults] unless specified as parameters.
+ *
+ * @param[id] The component id to use.
+ * @param[label] The button label
+ * @param[emoji] The button emoji
+ *
+ * @return[Button] The resulting button instance.
+ */
+fun primary(
+    id: String,
+    label: String? = ButtonDefaults.LABEL,
+    emoji: Emoji? = ButtonDefaults.EMOJI,
+    disabled: Boolean = ButtonDefaults.DISABLED,
+) = button(id, label, emoji, ButtonStyle.PRIMARY, disabled)
+
+/**
+ * Create a button with keyword arguments.
+ *
+ * This is a shortcut for a button of style secondary.
+ *
+ * This will use the defaults from [ButtonDefaults] unless specified as parameters.
+ *
+ * @param[id] The component id to use.
+ * @param[label] The button label
+ * @param[emoji] The button emoji
+ *
+ * @return[Button] The resulting button instance.
+ */
+fun secondary(
+    id: String,
+    label: String? = ButtonDefaults.LABEL,
+    emoji: Emoji? = ButtonDefaults.EMOJI,
+    disabled: Boolean = ButtonDefaults.DISABLED,
+) = button(id, label, emoji, ButtonStyle.SECONDARY, disabled)
+
+/**
+ * Create a button with keyword arguments.
+ *
+ * This is a shortcut for a button of style success.
+ *
+ * This will use the defaults from [ButtonDefaults] unless specified as parameters.
+ *
+ * @param[id] The component id to use.
+ * @param[label] The button label
+ * @param[emoji] The button emoji
+ *
+ * @return[Button] The resulting button instance.
+ */
+fun success(
+    id: String,
+    label: String? = ButtonDefaults.LABEL,
+    emoji: Emoji? = ButtonDefaults.EMOJI,
+    disabled: Boolean = ButtonDefaults.DISABLED,
+) = button(id, label, emoji, ButtonStyle.SUCCESS, disabled)
+
+/**
+ * Create a button with keyword arguments.
+ *
+ * This is a shortcut for a button of style danger.
+ *
+ * This will use the defaults from [ButtonDefaults] unless specified as parameters.
+ *
+ * @param[id] The component id to use.
+ * @param[label] The button label
+ * @param[emoji] The button emoji
+ *
+ * @return[Button] The resulting button instance.
+ */
+fun danger(
+    id: String,
+    label: String? = ButtonDefaults.LABEL,
+    emoji: Emoji? = ButtonDefaults.EMOJI,
+    disabled: Boolean = ButtonDefaults.DISABLED,
+) = button(id, label, emoji, ButtonStyle.DANGER, disabled)
+
+/**
+ * Create a button with keyword arguments.
+ *
+ * This is a shortcut for a button of style danger.
+ *
+ * This will use the defaults from [ButtonDefaults] unless specified as parameters.
+ *
+ * @param[id] The component id to use.
+ * @param[label] The button label
+ * @param[emoji] The button emoji
+ *
+ * @return[Button] The resulting button instance.
+ */
+fun link(
+    url: String,
+    label: String? = ButtonDefaults.LABEL,
+    emoji: Emoji? = ButtonDefaults.EMOJI,
+    disabled: Boolean = ButtonDefaults.DISABLED,
+) = button(url, label, emoji, ButtonStyle.LINK, disabled)
+
 
 
 /**
@@ -58,6 +181,7 @@ object ButtonDefaults {
  * @param[style] The button style.
  * @param[label] The button label
  * @param[emoji] The button emoji
+ * @param[disabled] Whether the button is disabled
  * @param[expiration] The relative expiration time for the listener in milliseconds
  * @param[user] The user who is authorized to click the button. If the button is pressed by another user it will just defer edit and ignore.
  * @param[listener] The callback for the button clicks
@@ -65,10 +189,11 @@ object ButtonDefaults {
  * @return[Button] The resulting button instance. You still need to send it with a message!
  */
 suspend fun JDA.button(style: ButtonStyle = ButtonDefaults.STYLE, label: String? = ButtonDefaults.LABEL, emoji: Emoji? = ButtonDefaults.EMOJI,
+                       disabled: Boolean = ButtonDefaults.DISABLED,
                        expiration: Long = ButtonDefaults.EXPIRATION, user: User? = null, listener: suspend (ButtonClickEvent) -> Unit
 ): Button {
     val id = ThreadLocalRandom.current().nextLong().toString()
-    val button = Button.of(style, id, label, emoji)
+    val button = button(id, label, emoji, style, disabled)
     val task = onButton(id) {
         if (user == null || user == it.user)
             listener(it)

--- a/src/main/kotlin/dev/minn/jda/ktx/messages/editing.kt
+++ b/src/main/kotlin/dev/minn/jda/ktx/messages/editing.kt
@@ -22,6 +22,7 @@ import net.dv8tion.jda.api.entities.MessageEmbed
 import net.dv8tion.jda.api.interactions.Interaction
 import net.dv8tion.jda.api.interactions.InteractionHook
 import net.dv8tion.jda.api.interactions.components.ActionRow
+import net.dv8tion.jda.api.requests.restaction.MessageAction
 import net.dv8tion.jda.api.requests.restaction.WebhookMessageUpdateAction
 import net.dv8tion.jda.api.requests.restaction.interactions.UpdateInteractionAction
 import net.dv8tion.jda.internal.JDAImpl
@@ -31,16 +32,35 @@ import net.dv8tion.jda.internal.requests.restaction.MessageActionImpl
 import net.dv8tion.jda.internal.requests.restaction.WebhookMessageUpdateActionImpl
 import net.dv8tion.jda.internal.requests.restaction.interactions.UpdateInteractionActionImpl
 
+/**
+ * Defaults used for edit message extensions provided by this module.
+ * Each function that relies on these defaults, says so explicitly. This does not apply for send functions.
+ *
+ * These can be changed but keep in mind they will apply globally.
+ */
 object MessageEditDefaults {
+    /**
+     * Whether message edits should replace the entire message by default
+     */
     var replace: Boolean = false
 }
 
+/**
+ * Add a collection of [NamedFile] to this request.
+ *
+ * @param[files] The files to add
+ */
 fun UpdateInteractionAction.addFiles(files: Files) {
     files.forEach {
         addFile(it.data, it.name, *it.options)
     }
 }
 
+/**
+ * Add a collection of [NamedFile] to this request.
+ *
+ * @param[files] The files to add
+ */
 fun <T> WebhookMessageUpdateAction<T>.addFiles(files: Files) {
     files.forEach {
         addFile(it.data, it.name, *it.options)
@@ -66,6 +86,23 @@ private fun <T> allOf(first: T?, other: Collection<T>?): List<T>? {
     return list
 }
 
+/**
+ * Edit the original message from this interaction.
+ *
+ * This makes use of [MessageEditDefaults].
+ *
+ * This does not currently replace files but may do so in the future.
+ *
+ * @param[content] The message content
+ * @param[embed] One embed
+ * @param[embeds] Multiple embeds
+ * @param[components] Components for this message
+ * @param[file] One file
+ * @param[files] Multiple files
+ * @param[replace] Whether this should replace the entire message
+ *
+ * @return[UpdateInteractionAction]
+ */
 fun Interaction.editMessage_(
     content: String? = null,
     embed: MessageEmbed? = null,
@@ -74,7 +111,7 @@ fun Interaction.editMessage_(
     file: NamedFile? = null,
     files: Files? = null,
     replace: Boolean = MessageEditDefaults.replace
-) = UpdateInteractionActionImpl(hook as InteractionHookImpl).apply {
+): UpdateInteractionAction = UpdateInteractionActionImpl(hook as InteractionHookImpl).apply {
     content.applyIf(replace) {
         setContent(it)
     }
@@ -95,6 +132,24 @@ fun Interaction.editMessage_(
     }
 }
 
+/**
+ * Edit a message from this interaction.
+ *
+ * This makes use of [MessageEditDefaults].
+ *
+ * This does not currently replace files but may do so in the future.
+ *
+ * @param[id] The message id, defaults to "@original"
+ * @param[content] The message content
+ * @param[embed] One embed
+ * @param[embeds] Multiple embeds
+ * @param[components] Components for this message
+ * @param[file] One file
+ * @param[files] Multiple files
+ * @param[replace] Whether this should replace the entire message
+ *
+ * @return[WebhookMessageUpdateAction]
+ */
 @Suppress("MoveLambdaOutsideParentheses")
 fun InteractionHook.editMessage(
     id: String = "@original",
@@ -105,7 +160,7 @@ fun InteractionHook.editMessage(
     file: NamedFile? = null,
     files: Files? = null,
     replace: Boolean = MessageEditDefaults.replace,
-) = WebhookMessageUpdateActionImpl(
+): WebhookMessageUpdateAction<Message> = WebhookMessageUpdateActionImpl(
     jda,
     Route.Interactions.EDIT_FOLLOWUP.compile(jda.selfUser.applicationId, interaction.token, id),
     { (jda as JDAImpl).entityBuilder.createMessage(it) }
@@ -130,6 +185,24 @@ fun InteractionHook.editMessage(
     }
 }
 
+/**
+ * Edit a message from this channel.
+ *
+ * This makes use of [MessageEditDefaults].
+ *
+ * This does not currently replace files but may do so in the future.
+ *
+ * @param[id] The message id
+ * @param[content] The message content
+ * @param[embed] One embed
+ * @param[embeds] Multiple embeds
+ * @param[components] Components for this message
+ * @param[file] One file
+ * @param[files] Multiple files
+ * @param[replace] Whether this should replace the entire message
+ *
+ * @return[MessageAction]
+ */
 fun MessageChannel.editMessage(
     id: String,
     content: String? = null,
@@ -139,7 +212,7 @@ fun MessageChannel.editMessage(
     file: NamedFile? = null,
     files: Files? = null,
     replace: Boolean = MessageEditDefaults.replace,
-) = MessageActionImpl(jda, id, this).apply {
+): MessageAction = MessageActionImpl(jda, id, this).apply {
     override(replace)
 
     content?.let {
@@ -162,6 +235,23 @@ fun MessageChannel.editMessage(
     }
 }
 
+/**
+ * Edit the message.
+ *
+ * This makes use of [MessageEditDefaults].
+ *
+ * This does not currently replace files but may do so in the future.
+ *
+ * @param[content] The message content
+ * @param[embed] One embed
+ * @param[embeds] Multiple embeds
+ * @param[components] Components for this message
+ * @param[file] One file
+ * @param[files] Multiple files
+ * @param[replace] Whether this should replace the entire message
+ *
+ * @return[MessageAction]
+ */
 fun Message.edit(
     content: String? = null,
     embed: MessageEmbed? = null,

--- a/src/main/kotlin/dev/minn/jda/ktx/messages/editing.kt
+++ b/src/main/kotlin/dev/minn/jda/ktx/messages/editing.kt
@@ -66,7 +66,7 @@ private fun <T> allOf(first: T?, other: Collection<T>?): List<T>? {
     return list
 }
 
-fun Interaction.edit(
+fun Interaction.editMessage_(
     content: String? = null,
     embed: MessageEmbed? = null,
     embeds: Embeds? = null,

--- a/src/main/kotlin/dev/minn/jda/ktx/messages/editing.kt
+++ b/src/main/kotlin/dev/minn/jda/ktx/messages/editing.kt
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2020 Florian Spieß
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.minn.jda.ktx.messages
+
+import net.dv8tion.jda.api.entities.Message
+import net.dv8tion.jda.api.entities.MessageChannel
+import net.dv8tion.jda.api.entities.MessageEmbed
+import net.dv8tion.jda.api.interactions.Interaction
+import net.dv8tion.jda.api.interactions.InteractionHook
+import net.dv8tion.jda.api.interactions.components.ActionRow
+import net.dv8tion.jda.api.requests.restaction.WebhookMessageUpdateAction
+import net.dv8tion.jda.api.requests.restaction.interactions.UpdateInteractionAction
+import net.dv8tion.jda.internal.JDAImpl
+import net.dv8tion.jda.internal.interactions.InteractionHookImpl
+import net.dv8tion.jda.internal.requests.Route
+import net.dv8tion.jda.internal.requests.restaction.MessageActionImpl
+import net.dv8tion.jda.internal.requests.restaction.WebhookMessageUpdateActionImpl
+import net.dv8tion.jda.internal.requests.restaction.interactions.UpdateInteractionActionImpl
+
+object MessageEditDefaults {
+    var replace: Boolean = false
+}
+
+fun UpdateInteractionAction.addFiles(files: Files) {
+    files.forEach {
+        addFile(it.data, it.name, *it.options)
+    }
+}
+
+fun <T> WebhookMessageUpdateAction<T>.addFiles(files: Files) {
+    files.forEach {
+        addFile(it.data, it.name, *it.options)
+    }
+}
+
+
+// Using an underscore at the end to prevent overload specialization
+// You can remove it with an import alias (import ... as foo) but i would recommend against it
+
+private inline fun <T> T.applyIf(check: Boolean, func: (T) -> Unit) {
+    if (check || this != null) {
+        func(this)
+    }
+}
+
+private fun <T> allOf(first: T?, other: Collection<T>?): List<T>? {
+    if (first == null && other == null)
+        return null
+    val list = mutableListOf<T>()
+    first?.let { list.add(it) }
+    other?.let { list.addAll(it) }
+    return list
+}
+
+fun Interaction.edit(
+    content: String? = null,
+    embed: MessageEmbed? = null,
+    embeds: Embeds? = null,
+    components: Components? = null,
+    file: NamedFile? = null,
+    files: Files? = null,
+    replace: Boolean = MessageEditDefaults.replace
+) = UpdateInteractionActionImpl(hook as InteractionHookImpl).apply {
+    content.applyIf(replace) {
+        setContent(it)
+    }
+
+    components.applyIf(replace) {
+        setActionRows(it?.mapNotNull { k -> k as? ActionRow } ?: emptyList())
+    }
+
+    allOf(embed, embeds).applyIf(replace) {
+        setEmbeds(it ?: emptyList())
+    }
+
+    allOf(file, files).applyIf(true) {
+        it?.let { addFiles(it) }
+// TODO: waiting for https://github.com/discord/discord-api-docs/discussions/3335
+//        if (replace)
+//            retainFilesById(LongRange(0, it?.size?.toLong() ?: 0L).map(Long::toString).toList())
+    }
+}
+
+@Suppress("MoveLambdaOutsideParentheses")
+fun InteractionHook.editMessage(
+    id: String = "@original",
+    content: String? = null,
+    embed: MessageEmbed? = null,
+    embeds: Embeds? = null,
+    components: Components? = null,
+    file: NamedFile? = null,
+    files: Files? = null,
+    replace: Boolean = MessageEditDefaults.replace,
+) = WebhookMessageUpdateActionImpl(
+    jda,
+    Route.Interactions.EDIT_FOLLOWUP.compile(jda.selfUser.applicationId, interaction.token, id),
+    { (jda as JDAImpl).entityBuilder.createMessage(it) }
+).apply {
+    content.applyIf(replace) {
+        setContent(it)
+    }
+
+    components.applyIf(replace) {
+        setActionRows(it?.mapNotNull { k -> k as? ActionRow } ?: emptyList())
+    }
+
+    allOf(embed, embeds).applyIf(replace) {
+        setEmbeds(it ?: emptyList())
+    }
+
+    allOf(file, files).applyIf(true) {
+        it?.let { addFiles(it) }
+// TODO: Wait for support in JDA for new attachments behavior
+//        if (replace)
+//            retainFilesById(LongRange(0, it?.size?.toLong() ?: 0L).map(Long::toString).toList())
+    }
+}
+
+fun MessageChannel.editMessage(
+    id: String,
+    content: String? = null,
+    embed: MessageEmbed? = null,
+    embeds: Embeds? = null,
+    components: Components? = null,
+    file: NamedFile? = null,
+    files: Files? = null,
+    replace: Boolean = MessageEditDefaults.replace,
+) = MessageActionImpl(jda, id, this).apply {
+    override(replace)
+
+    content?.let {
+        content(it)
+    }
+
+    components?.let {
+        setActionRows(it.mapNotNull { k -> k as? ActionRow })
+    }
+
+    allOf(embed, embeds)?.let {
+        setEmbeds(it)
+    }
+
+    allOf(file, files)?.let {
+        addFiles(it)
+// TODO: Wait for support in JDA for new attachments behavior
+//        if (replace)
+//            retainFilesById(LongRange(0, it.size.toLong()).map(Long::toString).toList())
+    }
+}
+
+fun Message.edit(
+    content: String? = null,
+    embed: MessageEmbed? = null,
+    embeds: Embeds? = null,
+    components: Components? = null,
+    file: NamedFile? = null,
+    files: Files? = null,
+    replace: Boolean = MessageEditDefaults.replace,
+) = channel.editMessage(id, content, embed, embeds, components, file, files, replace).reference(this)

--- a/src/main/kotlin/dev/minn/jda/ktx/messages/sending.kt
+++ b/src/main/kotlin/dev/minn/jda/ktx/messages/sending.kt
@@ -33,29 +33,65 @@ import net.dv8tion.jda.internal.requests.restaction.WebhookMessageActionImpl
 import net.dv8tion.jda.internal.requests.restaction.interactions.ReplyActionImpl
 
 // Defaults for keyword arguments
+/**
+ * Defaults used for send and reply extensions provided by this module.
+ * Each function that relies on these defaults, says so explicitly. This does not apply for edit functions.
+ *
+ * These can be changed but keep in mind they will apply globally.
+ */
 object SendDefaults {
+    /**
+     * The default message content.
+     */
     var content: String? = null
+
+    /**
+     * The default message embeds
+     */
     var embeds: Embeds = emptyList()
+
+    /**
+     * The default message components
+     */
     var components: Components = emptyList()
+
+    /**
+     * The default ephemeral state for interactions
+     */
     var ephemeral: Boolean = false
     // Not supporting files since input streams are single use and I don't think its worth it
 }
 
 // And you can also just add these to the individual actions easily
 
-fun MessageAction.addFiles(files: Files) {
+/**
+ * Add a collection of [NamedFile] to this request.
+ *
+ * @param[files] The files to add
+ */
+fun MessageAction.addFiles(files: Files) = apply {
     files.forEach {
         addFile(it.data, it.name, *it.options)
     }
 }
 
-fun ReplyAction.addFiles(files: Files) {
+/**
+ * Add a collection of [NamedFile] to this request.
+ *
+ * @param[files] The files to add
+ */
+fun ReplyAction.addFiles(files: Files) = apply {
     files.forEach {
         addFile(it.data, it.name, *it.options)
     }
 }
 
-fun <T> WebhookMessageAction<T>.addFiles(files: Files) {
+/**
+ * Add a collection of [NamedFile] to this request.
+ *
+ * @param[files] The files to add
+ */
+fun <T> WebhookMessageAction<T>.addFiles(files: Files) = apply {
     files.forEach {
         addFile(it.data, it.name, *it.options)
     }
@@ -64,6 +100,21 @@ fun <T> WebhookMessageAction<T>.addFiles(files: Files) {
 // Using an underscore at the end to prevent overload specialization
 // You can remove it with an import alias (import ... as foo) but i would recommend against it
 
+/**
+ * Send a reply to this interaction.
+ *
+ * This makes use of [SendDefaults].
+ *
+ * @param[content] The message content
+ * @param[embed] One embed
+ * @param[embeds] Multiple embeds
+ * @param[components] Components for this message
+ * @param[file] One file
+ * @param[files] Multiple files
+ * @param[ephemeral] Whether this message is ephemeral
+ *
+ * @see  [Interaction.deferReply]
+ */
 fun Interaction.reply_(
     content: String? = SendDefaults.content,
     embed: MessageEmbed? = null,
@@ -72,7 +123,7 @@ fun Interaction.reply_(
     file: NamedFile? = null,
     files: Files = emptyList(),
     ephemeral: Boolean = SendDefaults.ephemeral,
-) = ReplyActionImpl(hook as InteractionHookImpl).apply {
+): ReplyAction = ReplyActionImpl(hook as InteractionHookImpl).apply {
     setContent(content)
     setEphemeral(ephemeral)
 
@@ -92,6 +143,23 @@ fun Interaction.reply_(
     addFiles(files)
 }
 
+/**
+ * Send a reply to this interaction.
+ *
+ * This makes use of [SendDefaults].
+ *
+ * @param[content] The message content
+ * @param[embed] One embed
+ * @param[embeds] Multiple embeds
+ * @param[components] Components for this message
+ * @param[file] One file
+ * @param[files] Multiple files
+ * @param[ephemeral] Whether this message is ephemeral
+ *
+ * @return[WebhookMessageAction]
+ *
+ * @see  [Interaction.deferReply]
+ */
 @Suppress("MoveLambdaOutsideParentheses")
 fun InteractionHook.send(
     content: String? = SendDefaults.content,
@@ -101,7 +169,7 @@ fun InteractionHook.send(
     file: NamedFile? = null,
     files: Files = emptyList(),
     ephemeral: Boolean = SendDefaults.ephemeral,
-) = WebhookMessageActionImpl(
+): WebhookMessageAction<Message> = WebhookMessageActionImpl(
     jda,
     interaction.messageChannel,
     Route.Interactions.CREATE_FOLLOWUP.compile(jda.selfUser.applicationId, interaction.token),
@@ -126,6 +194,20 @@ fun InteractionHook.send(
     addFiles(files)
 }
 
+/**
+ * Send a message in this channel.
+ *
+ * This makes use of [SendDefaults].
+ *
+ * @param[content] The message content
+ * @param[embed] One embed
+ * @param[embeds] Multiple embeds
+ * @param[components] Components for this message
+ * @param[file] One file
+ * @param[files] Multiple files
+ *
+ * @return[MessageAction]
+ */
 fun MessageChannel.send(
     content: String? = SendDefaults.content,
     embed: MessageEmbed? = null,
@@ -133,7 +215,7 @@ fun MessageChannel.send(
     components: Components = SendDefaults.components,
     file: NamedFile? = null,
     files: Files = emptyList(),
-) = MessageActionImpl(jda, null, this).apply {
+): MessageAction = MessageActionImpl(jda, null, this).apply {
     content(content)
 
     if (components.isNotEmpty()) {
@@ -152,6 +234,20 @@ fun MessageChannel.send(
     addFiles(files)
 }
 
+/**
+ * Send a reply to this message in the same channel.
+ *
+ * This makes use of [SendDefaults].
+ *
+ * @param[content] The message content
+ * @param[embed] One embed
+ * @param[embeds] Multiple embeds
+ * @param[components] Components for this message
+ * @param[file] One file
+ * @param[files] Multiple files
+ *
+ * @return[MessageAction]
+ */
 fun Message.reply_(
     content: String? = SendDefaults.content,
     embed: MessageEmbed? = null,

--- a/src/main/kotlin/dev/minn/jda/ktx/messages/sending.kt
+++ b/src/main/kotlin/dev/minn/jda/ktx/messages/sending.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package dev.minn.jda.ktx
+package dev.minn.jda.ktx.messages
 
 import net.dv8tion.jda.api.entities.Message
 import net.dv8tion.jda.api.entities.MessageChannel
@@ -22,25 +22,15 @@ import net.dv8tion.jda.api.entities.MessageEmbed
 import net.dv8tion.jda.api.interactions.Interaction
 import net.dv8tion.jda.api.interactions.InteractionHook
 import net.dv8tion.jda.api.interactions.components.ActionRow
-import net.dv8tion.jda.api.interactions.components.Component
-import net.dv8tion.jda.api.interactions.components.ComponentLayout
 import net.dv8tion.jda.api.requests.restaction.MessageAction
 import net.dv8tion.jda.api.requests.restaction.WebhookMessageAction
 import net.dv8tion.jda.api.requests.restaction.interactions.ReplyAction
-import net.dv8tion.jda.api.requests.restaction.interactions.UpdateInteractionAction
-import net.dv8tion.jda.api.utils.AttachmentOption
 import net.dv8tion.jda.internal.JDAImpl
 import net.dv8tion.jda.internal.interactions.InteractionHookImpl
 import net.dv8tion.jda.internal.requests.Route
 import net.dv8tion.jda.internal.requests.restaction.MessageActionImpl
 import net.dv8tion.jda.internal.requests.restaction.WebhookMessageActionImpl
 import net.dv8tion.jda.internal.requests.restaction.interactions.ReplyActionImpl
-import java.io.File
-import java.io.InputStream
-
-typealias Components = Collection<ComponentLayout>
-typealias Embeds = Collection<MessageEmbed>
-typealias Files = Collection<NamedFile>
 
 // Defaults for keyword arguments
 object SendDefaults {
@@ -51,75 +41,6 @@ object SendDefaults {
     // Not supporting files since input streams are single use and I don't think its worth it
 }
 
-// Custom data class used to make sending files simpler
-data class NamedFile(
-    val name: String,
-    val data: InputStream,
-    val options: Array<out AttachmentOption> = emptyArray()
-) {
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as NamedFile
-
-        if (name != other.name) return false
-        if (data != other.data) return false
-        if (!options.contentEquals(other.options)) return false
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        var result = name.hashCode()
-        result = 31 * result + data.hashCode()
-        result = 31 * result + options.contentHashCode()
-        return result
-    }
-}
-
-
-@JvmName("intoComponents")
-fun <T : Component> Collection<T>.into() = listOf(ActionRow.of(this))
-fun Component.into() = listOf(this).into()
-fun ComponentLayout.into() = listOf(this)
-
-// Lots of conversion methods you can use to convert your collections to named files
-//
-// mapOf(
-//   "cat.gif" to File("123.gif"),
-//   "thing.txt" to File("thing.txt")
-// ).into() // -> Collection<NamedFile> = Files
-
-@JvmName("intoNamedFile")
-fun Collection<File>.into() = map { NamedFile(it.name, it.inputStream()) }
-@JvmName("mapFilesIntoNamedFiles")
-fun Map<String, File>.into() = map { NamedFile(it.key, it.value.inputStream()) }
-@JvmName("mapStreamsIntoNamedFiles")
-fun Map<String, InputStream>.into() = map { NamedFile(it.key, it.value) }
-@JvmName("mapArrayIntoNamedFiles")
-fun Map<String, ByteArray>.into() = map { NamedFile(it.key, it.value.inputStream()) }
-
-
-// fun eval(code: String): EvalResult { ... }
-//
-// val (stdout, stderr) = eval(code)
-// val outputs = listOf(stdout.named("stdout.txt"), stderr.named("stderr.txt"))
-// event.reply_(files=outputs).queue()
-
-fun InputStream.named(name: String, vararg options: AttachmentOption) = NamedFile(name, this, options)
-fun ByteArray.named(name: String, vararg options: AttachmentOption) = NamedFile(name, this.inputStream(), options)
-fun File.named(name: String, vararg options: AttachmentOption) = NamedFile(name, this.inputStream(), options)
-
-// val outputs = listOf("stdout.txt"(stdout), "stderr"(stderr))
-
-operator fun String.invoke(file: InputStream, vararg options: AttachmentOption) = file.named(this, *options)
-operator fun String.invoke(file: ByteArray, vararg options: AttachmentOption) = file.named(this, *options)
-operator fun String.invoke(file: File, vararg options: AttachmentOption) = file.named(this, *options)
-
-// If you want to just use the file name
-fun File.into() = listOf(this).into()
-
 // And you can also just add these to the individual actions easily
 
 fun MessageAction.addFiles(files: Files) {
@@ -129,12 +50,6 @@ fun MessageAction.addFiles(files: Files) {
 }
 
 fun ReplyAction.addFiles(files: Files) {
-    files.forEach {
-        addFile(it.data, it.name, *it.options)
-    }
-}
-
-fun UpdateInteractionAction.addFiles(files: Files) {
     files.forEach {
         addFile(it.data, it.name, *it.options)
     }

--- a/src/main/kotlin/dev/minn/jda/ktx/messages/utils.kt
+++ b/src/main/kotlin/dev/minn/jda/ktx/messages/utils.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2020 Florian Spieß
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.minn.jda.ktx.messages
+
+import net.dv8tion.jda.api.entities.MessageEmbed
+import net.dv8tion.jda.api.interactions.components.ActionRow
+import net.dv8tion.jda.api.interactions.components.Component
+import net.dv8tion.jda.api.interactions.components.ComponentLayout
+import net.dv8tion.jda.api.utils.AttachmentOption
+import java.io.File
+import java.io.InputStream
+
+typealias Components = Collection<ComponentLayout>
+typealias Embeds = Collection<MessageEmbed>
+typealias Files = Collection<NamedFile>
+
+// Custom data class used to make sending files simpler
+data class NamedFile(
+    val name: String,
+    val data: InputStream,
+    val options: Array<out AttachmentOption> = emptyArray()
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as NamedFile
+
+        if (name != other.name) return false
+        if (data != other.data) return false
+        if (!options.contentEquals(other.options)) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = name.hashCode()
+        result = 31 * result + data.hashCode()
+        result = 31 * result + options.contentHashCode()
+        return result
+    }
+}
+
+
+@JvmName("intoComponents")
+fun <T : Component> Collection<T>.into() = listOf(ActionRow.of(this))
+fun Component.into() = listOf(this).into()
+fun ComponentLayout.into() = listOf(this)
+
+// Lots of conversion methods you can use to convert your collections to named files
+//
+// mapOf(
+//   "cat.gif" to File("123.gif"),
+//   "thing.txt" to File("thing.txt")
+// ).into() // -> Collection<NamedFile> = Files
+
+@JvmName("intoNamedFile")
+fun Collection<File>.into() = map { NamedFile(it.name, it.inputStream()) }
+@JvmName("mapFilesIntoNamedFiles")
+fun Map<String, File>.into() = map { NamedFile(it.key, it.value.inputStream()) }
+@JvmName("mapStreamsIntoNamedFiles")
+fun Map<String, InputStream>.into() = map { NamedFile(it.key, it.value) }
+@JvmName("mapArrayIntoNamedFiles")
+fun Map<String, ByteArray>.into() = map { NamedFile(it.key, it.value.inputStream()) }
+
+
+// fun eval(code: String): EvalResult { ... }
+//
+// val (stdout, stderr) = eval(code)
+// val outputs = listOf(stdout.named("stdout.txt"), stderr.named("stderr.txt"))
+// event.reply_(files=outputs).queue()
+
+fun InputStream.named(name: String, vararg options: AttachmentOption) = NamedFile(name, this, options)
+fun ByteArray.named(name: String, vararg options: AttachmentOption) = NamedFile(name, this.inputStream(), options)
+fun File.named(name: String, vararg options: AttachmentOption) = NamedFile(name, this.inputStream(), options)
+
+// val outputs = listOf("stdout.txt"(stdout), "stderr"(stderr))
+
+operator fun String.invoke(file: InputStream, vararg options: AttachmentOption) = file.named(this, *options)
+operator fun String.invoke(file: ByteArray, vararg options: AttachmentOption) = file.named(this, *options)
+operator fun String.invoke(file: File, vararg options: AttachmentOption) = file.named(this, *options)
+
+// If you want to just use the file name
+fun File.into() = listOf(this).into()

--- a/src/main/kotlin/dev/minn/jda/ktx/messages/utils.kt
+++ b/src/main/kotlin/dev/minn/jda/ktx/messages/utils.kt
@@ -28,7 +28,25 @@ typealias Components = Collection<ComponentLayout>
 typealias Embeds = Collection<MessageEmbed>
 typealias Files = Collection<NamedFile>
 
-// Custom data class used to make sending files simpler
+/**
+ * A custom data class used to represent named files for message attachments.
+ *
+ * ## Example
+ *
+ * ```kt
+ * val files: Collection<NamedFile> = listOf(File("cat.gif"), File("dog.jpg")).into()
+ * val file: NamedFile = File("cat.gif").named("notcat.gif")
+ * ```
+ *
+ * @param[name] The filename to use
+ * @param[data] The file contents as an input stream
+ * @param[options] Attachment options
+ *
+ * @see  [File.into]
+ * @see  [File.named]
+ * @see  [InputStream.named]
+ * @see  [ByteArray.named]
+ */
 data class NamedFile(
     val name: String,
     val data: InputStream,
@@ -56,9 +74,28 @@ data class NamedFile(
 }
 
 
+/**
+ * Converts the collection of components into a collection of a single [ActionRow].
+ *
+ * @param[T] The component type such as button
+ *
+ * @return[List] of [ActionRow]
+ */
 @JvmName("intoComponents")
 fun <T : Component> Collection<T>.into() = listOf(ActionRow.of(this))
+
+/**
+ * Wraps the component into a collection of a single [ActionRow].
+ *
+ * @return[List] of [ActionRow]
+ */
 fun Component.into() = listOf(this).into()
+
+/**
+ * Wraps the component layout into a collection of layouts.
+ *
+ * @return[List] of [ComponentLayout]
+ */
 fun ComponentLayout.into() = listOf(this)
 
 // Lots of conversion methods you can use to convert your collections to named files
@@ -68,12 +105,36 @@ fun ComponentLayout.into() = listOf(this)
 //   "thing.txt" to File("thing.txt")
 // ).into() // -> Collection<NamedFile> = Files
 
+/**
+ * Converts a collection of [File] into a [List] or [NamedFile].
+ *
+ * @return[List] of [NamedFile]
+ */
 @JvmName("intoNamedFile")
 fun Collection<File>.into() = map { NamedFile(it.name, it.inputStream()) }
+
+/**
+ * Converts this map to a [List] of [NamedFile].
+ * This will use the keys as file names.
+ *
+ * @return[List] of [NamedFile]
+ */
 @JvmName("mapFilesIntoNamedFiles")
 fun Map<String, File>.into() = map { NamedFile(it.key, it.value.inputStream()) }
+/**
+ * Converts this map to a [List] of [NamedFile].
+ * This will use the keys as file names.
+ *
+ * @return[List] of [NamedFile]
+ */
 @JvmName("mapStreamsIntoNamedFiles")
 fun Map<String, InputStream>.into() = map { NamedFile(it.key, it.value) }
+/**
+ * Converts this map to a [List] of [NamedFile].
+ * This will use the keys as file names.
+ *
+ * @return[List] of [NamedFile]
+ */
 @JvmName("mapArrayIntoNamedFiles")
 fun Map<String, ByteArray>.into() = map { NamedFile(it.key, it.value.inputStream()) }
 
@@ -84,15 +145,52 @@ fun Map<String, ByteArray>.into() = map { NamedFile(it.key, it.value.inputStream
 // val outputs = listOf(stdout.named("stdout.txt"), stderr.named("stderr.txt"))
 // event.reply_(files=outputs).queue()
 
+/**
+ * Wraps this InputStream in a [NamedFile]
+ *
+ * @param[name] The name of the file
+ * @param[options] The attachment options
+ *
+ * @return[NamedFile]
+ */
 fun InputStream.named(name: String, vararg options: AttachmentOption) = NamedFile(name, this, options)
+
+/**
+ * Wraps this ByteArray in a [NamedFile]
+ *
+ * @param[name] The name of the file
+ * @param[options] The attachment options
+ *
+ * @return[NamedFile]
+ */
 fun ByteArray.named(name: String, vararg options: AttachmentOption) = NamedFile(name, this.inputStream(), options)
+
+/**
+ * Wraps this File in a [NamedFile]
+ *
+ * @param[name] The name of the file
+ * @param[options] The attachment options
+ *
+ * @return[NamedFile]
+ *
+ * @see[File.into]
+ */
 fun File.named(name: String, vararg options: AttachmentOption) = NamedFile(name, this.inputStream(), options)
 
 // val outputs = listOf("stdout.txt"(stdout), "stderr"(stderr))
+// there are kind of a meme, no need to document tbh
 
 operator fun String.invoke(file: InputStream, vararg options: AttachmentOption) = file.named(this, *options)
 operator fun String.invoke(file: ByteArray, vararg options: AttachmentOption) = file.named(this, *options)
 operator fun String.invoke(file: File, vararg options: AttachmentOption) = file.named(this, *options)
 
 // If you want to just use the file name
+
+/**
+ * Wraps this File in a [NamedFile]
+ *
+ * @return[NamedFile]
+ *
+ * @see[File.named]
+ */
 fun File.into() = listOf(this).into()

--- a/src/main/kotlin/dev/minn/jda/ktx/sending.kt
+++ b/src/main/kotlin/dev/minn/jda/ktx/sending.kt
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2020 Florian Spieß
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.minn.jda.ktx
+
+import net.dv8tion.jda.api.entities.Message
+import net.dv8tion.jda.api.entities.MessageChannel
+import net.dv8tion.jda.api.entities.MessageEmbed
+import net.dv8tion.jda.api.interactions.Interaction
+import net.dv8tion.jda.api.interactions.InteractionHook
+import net.dv8tion.jda.api.interactions.components.ActionRow
+import net.dv8tion.jda.api.interactions.components.Component
+import net.dv8tion.jda.api.interactions.components.ComponentLayout
+import net.dv8tion.jda.api.utils.AttachmentOption
+import net.dv8tion.jda.internal.JDAImpl
+import net.dv8tion.jda.internal.interactions.InteractionHookImpl
+import net.dv8tion.jda.internal.requests.Route
+import net.dv8tion.jda.internal.requests.restaction.MessageActionImpl
+import net.dv8tion.jda.internal.requests.restaction.WebhookMessageActionImpl
+import net.dv8tion.jda.internal.requests.restaction.interactions.ReplyActionImpl
+import java.io.File
+import java.io.InputStream
+
+typealias Components = Collection<ComponentLayout>
+typealias Embeds = Collection<MessageEmbed>
+typealias Files = Collection<NamedFile>
+
+object SendDefaults {
+    var content: String? = null
+    var embed: MessageEmbed? = null
+    var embeds: Embeds = emptyList()
+    var components: Components = emptyList()
+    var ephemeral: Boolean = false
+}
+
+data class NamedFile(
+    val name: String,
+    val data: InputStream,
+    val options: Collection<AttachmentOption> = emptyList()
+)
+
+
+@JvmName("intoComponents")
+fun <T : Component> Collection<T>.into() = listOf(ActionRow.of(this))
+fun Component.into() = listOf(this).into()
+fun ComponentLayout.into() = listOf(this)
+
+@JvmName("intoNamedFile")
+fun Collection<File>.into() = map { NamedFile(it.name, it.inputStream()) }
+@JvmName("mapFilesIntoNamedFiles")
+fun Map<String, File>.into() = map { NamedFile(it.key, it.value.inputStream()) }
+@JvmName("mapStreamsIntoNamedFiles")
+fun Map<String, InputStream>.into() = map { NamedFile(it.key, it.value) }
+@JvmName("mapArrayIntoNamedFiles")
+fun Map<String, ByteArray>.into() = map { NamedFile(it.key, it.value.inputStream()) }
+
+fun File.into() = listOf(this).into()
+
+
+fun Interaction.reply(
+    content: String? = SendDefaults.content,
+    embed: MessageEmbed? = SendDefaults.embed,
+    embeds: Embeds = SendDefaults.embeds,
+    components: Components = SendDefaults.components,
+    files: Files = emptyList(),
+    ephemeral: Boolean = SendDefaults.ephemeral,
+) = ReplyActionImpl(hook as InteractionHookImpl).apply {
+    setContent(content)
+    setEphemeral(ephemeral)
+
+    if (components.isNotEmpty()) {
+        addActionRows(components.mapNotNull { it as? ActionRow })
+    }
+
+    if (embed != null) {
+        addEmbeds(embed)
+    }
+
+    if (embeds.isNotEmpty()) {
+        addEmbeds(embeds)
+    }
+
+    files.forEach {
+        addFile(it.data, it.name, *it.options.toTypedArray())
+    }
+}
+
+@Suppress("MoveLambdaOutsideParentheses")
+fun InteractionHook.send(
+    content: String? = SendDefaults.content,
+    embed: MessageEmbed? = SendDefaults.embed,
+    embeds: Embeds = SendDefaults.embeds,
+    components: Components = SendDefaults.components,
+    files: Files = emptyList(),
+    ephemeral: Boolean = SendDefaults.ephemeral,
+) = WebhookMessageActionImpl(
+    jda,
+    interaction.messageChannel,
+    Route.Interactions.CREATE_FOLLOWUP.compile(jda.selfUser.applicationId, interaction.token),
+    { (jda as JDAImpl).entityBuilder.createMessage(it) }
+).apply {
+    setContent(content)
+    setEphemeral(ephemeral)
+
+    if (components.isNotEmpty()) {
+        addActionRows(components.mapNotNull { it as? ActionRow })
+    }
+
+    if (embed != null) {
+        addEmbeds(embed)
+    }
+
+    if (embeds.isNotEmpty()) {
+        addEmbeds(embeds)
+    }
+
+    files.forEach {
+        addFile(it.data, it.name, *it.options.toTypedArray())
+    }
+}
+
+fun MessageChannel.send(
+    content: String? = SendDefaults.content,
+    embed: MessageEmbed? = SendDefaults.embed,
+    embeds: Embeds = SendDefaults.embeds,
+    components: Components = SendDefaults.components,
+    files: Files = emptyList(),
+) = MessageActionImpl(jda, null, this).apply {
+    content(content)
+
+    if (components.isNotEmpty()) {
+        setActionRows(components.mapNotNull { it as? ActionRow })
+    }
+
+    if (embed != null) {
+        setEmbeds(embed)
+    }
+
+    if (embeds.isNotEmpty()) {
+        setEmbeds(embeds)
+    }
+
+    files.forEach {
+        addFile(it.data, it.name, *it.options.toTypedArray())
+    }
+}
+
+fun Message.reply(
+    content: String? = SendDefaults.content,
+    embed: MessageEmbed? = SendDefaults.embed,
+    embeds: Embeds = SendDefaults.embeds,
+    components: Components = SendDefaults.components,
+    files: Files = emptyList(),
+) = channel.send(content, embed, embeds, components, files).reference(this)


### PR DESCRIPTION
Example usage:

``` kt
SendDefaults.ephemeral = true // <- all reply_ calls set ephemeral=true by default
jda.onCommand("ban") { event ->
    if (!event.member.hasPermission(Permission.BAN_MEMBERS))
        return@onCommand event.reply_("You can't do that!").queue()
    
    event.reply_("Are you sure?", components=danger("ban", "Yes!").into())
    val interaction = event.user.awaitButton("ban")
    val user = event.getOption("target").asUser
    event.guild!!.ban(user, 0).queue()
    interaction.editMessage_("Successfully banned user", components=emptyList()).queue()
}
```