### PR TITLE
Fix attachment flag being set when editing a message via the MessageEdit function without any changes to the attachments

### DIFF
--- a/src/main/kotlin/dev/minn/jda/ktx/messages/builder.kt
+++ b/src/main/kotlin/dev/minn/jda/ktx/messages/builder.kt
@@ -187,10 +187,11 @@ class InlineMessage<T>(val builder: AbstractMessageBuilder<T, *>) {
             setComponents(configuredComponents)
         }
 
-        if (this is MessageEditBuilder && set and SetFlags.FILES != 0)
-            setAttachments(configuredFiles)
-        else
-            setFiles(configuredFiles.mapNotNull { it as? FileUpload })
+        if (set and SetFlags.FILES != 0) {
+            if (this is MessageEditBuilder)
+                setAttachments(configuredFiles)
+            else setFiles(configuredFiles.mapNotNull { it as? FileUpload })
+        }
     }.build()
 
     var content: String? = null


### PR DESCRIPTION
Fixes #43
